### PR TITLE
add pre-commit for checking yaml and whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+---
+default_stages: [commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+    - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This website is built using:
 
 First, run `npm install` to install all required node modules. Then run `hugo` to build all assets. Finally, run `hugo serve` to access the website at http://localhost:1313.
 
+## Pre-commit
+To use the supplied pre-commit hooks, run `pre-commit install`.
+
 ## Contributing
 
 This website makes heavily use of Hugo for the content management. There are some guidelines to follow:


### PR DESCRIPTION
Example of trying to commit a malformed yaml with whitespace added as well..

```
Trim Trailing Whitespace.................................................Failed
hookid: trailing-whitespace

Files were modified by this hook. Additional output:

Fixing data/team.yml

Check Yaml...............................................................Failed
hookid: check-yaml

while scanning a simple key
  in "data/team.yml", line 65, column 5
could not find expected ':'
  in "data/team.yml", line 66, column 5
```