### PR TITLE
add GitPod config and custom Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+
+RUN brew install hugo

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,7 @@
 FROM gitpod/workspace-full
 
-RUN brew install hugo
+ARG HUGO_VERSION="0.73.0"
+RUN curl -LJo /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb && \
+    sudo dpkg -i /tmp/hugo.deb && \
+    DEBIAN_FRONTEND=noninteractive sudo apt install -y -qq libsass1 && \
+    rm /tmp/hugo.deb

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,7 @@ image:
 tasks:
   - init: npm install
     command: hugo serve
+
+ports:
+  - port: 1313
+    onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+# Docs: https://www.gitpod.io/docs/config-gitpod-file
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: npm install
+    command: hugo serve


### PR DESCRIPTION
This PR adds support for [GitPod](https://gitpod.io). GitPod offers reproducible disposable dev environments as a service. This means: 

- You can reliably develop without having to set up anything locally
- You can develop using a ChromeBook or iPad
- You can still link it to your local VSCode or JetBrains IDE
- You can still expose the `hugo` process (started by default) locally to see your changes on `http://localhost:1313`
- You can switch back and forth between branches that have vastly different NPM packages without having to think about how to manage that locally

 