### PR TITLE
change hugo serve in Gitpod to work consistently for browser and vscode

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,8 +4,8 @@ image:
 
 tasks:
   - init: npm install
-    command: hugo serve
+    command: hugo serve --baseURL https://1313-${GITPOD_WORKSPACE_ID}.${GITPOD_WORKSPACE_CLUSTER_HOST}/ --appendPort=false
 
 ports:
   - port: 1313
-    onOpen: open-browser
+    onOpen: ignore


### PR DESCRIPTION
**What does this solve?**
The Gitpod environment was configured to run `hugo serve` on startup. By default, this will bind to `localhost` and expect a base URL of `http://localhost:1313`. When using your local IDE (VSCode) with port-forwarding, this works brilliantly. However, if you edit in the browser, there's no such thing as forwarding the port, so instead Gitpod also creates an ingress, and offers that to you → `https://<portnumber>-<workspace id>.<gitpod cluster hostname>/`. As this hostname obviously is different from what `hugo` is expecting, the preview has all kinds of rendering issues.

I've resolved this by changing the `hugo serve` command to _always_ use the ingress hostname instead, by parsing the relevant envvars. On startup, the terminal should show you the correct URL:

![image](https://user-images.githubusercontent.com/10847042/162418658-9122f1d7-c9b1-4d35-87f2-bfc8410ab48f.png)

I've found this behaviour to work consistently from both the browser-based editor and my local VSCode. 


Test by using the 'Gitpod' check

![image](https://user-images.githubusercontent.com/10847042/162405719-8e5e0cfc-1aba-4bca-b14b-0b5055a22963.png)
