### PR TITLE
Fixes suboptimal localdev Docker images

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-node-lts
+FROM gitpod/workspace-full
 
 ARG HUGO_VERSION="0.73.0"
 RUN curl -LJo /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-node-lts
 
 ARG HUGO_VERSION="0.73.0"
 RUN curl -LJo /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb && \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,3 @@
-
 image:
   file: .gitpod.Dockerfile
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM ubuntu:latest
+FROM ubuntu:focal
+
+ARG HUGO_VERSION="0.73.0"
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+    apt install -y -qq curl && \
+    curl -LJo /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb && \
+    dpkg -i /tmp/hugo.deb && \
+    apt install -y -qq nodejs npm libsass1 && \
+    apt clean && \
+    rm /tmp/hugo.deb
+
 WORKDIR /website
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y -qq nodejs npm hugo 
 ENTRYPOINT ["sh","-c"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This website is built using:
 
- * Hugo 0.55+
+ * Hugo 0.73
  * Bootstrap 4
  * Font-awesome
  * Ion icons
@@ -12,17 +12,18 @@ This website is built using:
 ### GitPod
 The easiest way to work on the Skyworkz website is to use GitPod. GitPod offers a browser-based VSCode setup that has a completely pre-configured setup for the website, including a running Hugo development server. You can use GitPod free of charge with your Github account. To use Gitpod, visit: https://gitpod.io/#https://github.com/skyworkz/website
 
-### Local
-First, run `npm install` to install all required node modules. Then run `hugo` to build all assets. Finally, run `hugo serve` to access the website at http://localhost:1313.
-
 ### Optional: using a Docker image for building the code
-For some reason, `npm` does not work correctly on macOS (or Windows). If you encounter problems when using `hugo` after `npm install` like `hugo` complaining about SASS stuff, you can use the bundled `Dockerfile` as follows:
+If for some reason, you can't or don't want to use Gitpod, you can use a local Docker setup. If you encounter problems when using `hugo` after `npm install` like `hugo` complaining about SASS stuff, you can use the bundled `Dockerfile` as follows:
 ```bash
 docker build -t skyworkz .
 docker run -it -v $(pwd):/website skyworkz "npm install"
 docker run -it -v $(pwd):/website -p 1313:1313 skyworkz "hugo serve"
 ```
 Now, you can make changed to the website and they will automatically be reflected in the dev server (accessed by navigating to `localhost:1313` as mentioned above.
+
+### Optional: run your own local setup
+First, make sure you get a Node 16.x setup, and install Hugo (extended) in the correct version. Then, run `npm install` to install all required node modules. Finally, run `hugo serve` to access the website at http://localhost:1313.
+
 ### Pre-commit
 To use the supplied pre-commit hooks, run `pre-commit install`.
 
@@ -36,5 +37,11 @@ This website makes heavily use of Hugo for the content management. There are som
  ## Pull-request process
  To contribute content or code you need to create pull-request. We make use of `CODEOWNERS` for automatic assignment of pull-requests to ensure that your PR is reviewed by the most appropriate people in a timely manner.
 
-## Questions
-If you have any questions, ask Bas :)
+## Questions / Maintainers
+If you have any questions or want to discuss something with the maintainers team, feel free to join the `#skyworkz-website-maintainers` channel.
+
+Currently, the maintainers team consists of:
+- Bas
+- Benny
+- Lee
+- Nidhi

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,17 +675,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@sideway/address": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
@@ -11239,8 +11228,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-4.4.2.tgz",
       "integrity": "sha512-axjfMhxEXHShV3r2TZjf+2niJ1C6LdAxkHKmg7mVq4jXtUQHOldU5XsjV0v2lUAt1urJBFi2zajfK8798ukL3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@fullhuman/postcss-purgecss": {
       "version": "4.0.3",
@@ -11345,13 +11333,6 @@
           }
         }
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "dev": true,
-      "peer": true
     },
     "@sideway/address": {
       "version": "4.1.0",
@@ -11713,8 +11694,7 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "requires": {}
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -11779,15 +11759,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
       "integrity": "sha1-S4Mee1MUFafMUYzUBOc/YZPGNJ0=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "animate.css": {
       "version": "3.7.2",
@@ -12230,8 +12208,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -15062,8 +15039,7 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
           "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
@@ -16919,8 +16895,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-remove-unused-css/-/postcss-remove-unused-css-1.0.4.tgz",
       "integrity": "sha1-cwmNTb/U9q40lqAFRaDluXgv68s=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-reporter": {
       "version": "6.0.1",
@@ -16982,15 +16957,13 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-uncss": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/postcss-uncss/-/postcss-uncss-0.16.1.tgz",
       "integrity": "sha1-RjvT5iltR/hq1ZgzqQ8IUocaRiE=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-url": {
       "version": "8.0.0",
@@ -18190,8 +18163,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
       "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "4.3.0",
@@ -18451,8 +18423,7 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "requires": {}
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "p-limit": {
           "version": "3.1.0",
@@ -18935,8 +18906,7 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "requires": {}
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "mime-db": {
           "version": "1.50.0",


### PR DESCRIPTION
This PR fixes: 

- original localdev `Dockerfile` used `ubuntu:latest` as its base, but it should use `ubuntu:focal` to be consistent with both GitPod and Netlify environments
- ~~Gitpod Dockerfile used `gitpod/workspace-full` but we seem to be able to use the much smaller `gitpod/workspace-node-lts` image instead (which should save approximately 4.5GB in the resulting Gitpod image)~~ (this change was rolled back as it had negative side-effects)
- Add `.npmrc` to enable legacy peer depedencies on the project level. We need this currently because otherwise `npm install` breaks