### PR TITLE
chore: remove Nidhi from maintainers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,3 @@ Currently, the maintainers team consists of:
 - Bas
 - Benny
 - Lee
-- Nidhi


### PR DESCRIPTION
By her own request, remove Nidhi from the maintainers (at least for now)