### PR TITLE
fix issue where popovers on team page used small images and improve spacing

### DIFF
--- a/layouts/partials/team.html
+++ b/layouts/partials/team.html
@@ -63,7 +63,7 @@
                     </div>
                     <div class="modal-body">
                       {{ .description | markdownify }}
-                      <img src="{{ $image300.RelPermalink }}" class="img-fluid mt-3">
+                      <img src="{{ $image600.RelPermalink }}" class="img-fluid mt-3">
                     </div>
                     <div class="modal-footer">
                       </div>
@@ -130,7 +130,7 @@
                     </div>
                     <div class="modal-body">
                       {{ .description | markdownify }}
-                      <img src="{{ $image300.RelPermalink }}" class="img-fluid">
+                      <img src="{{ $image600.RelPermalink }}" class="img-fluid mt-3">
                     </div>
                     <div class="modal-footer">
                     </div>


### PR DESCRIPTION
The popovers for people on the Team page used the small 300x300px images instead of the also rendered 600x600 versions, making them look fuzzy. This PR fixes that and also incorporates an improvement suggested by @RyanSusana that adds a little extra spacing. 