### PR TITLE
replace broken calendarhero integration with reclaim.ai integration

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -44,8 +44,8 @@
       <div class="col-12">
           <div class="block">
             <h2>Book a meeting</h2>
-            <p>You can quickly book a meeting with Bas or call yourself using the button below:</p>
-            <a href="https://app.reclaim.ai/m/bas" target="_blank"><button>Schedule Meeting</button></a>
+            <p>You can quickly book a meeting or call with Bas yourself using the button below:</p>
+            <a class="btn btn-info mt-lg-2" id="book-meeting-bas" href="https://app.reclaim.ai/m/bas" target="_blank">Schedule Meeting</a>
           </div>
         </div>
         </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -32,9 +32,9 @@
             {{ with .gmaps}}
             <div class="block">
               <h2>{{ .title }}</h2>
-              <div class="google-map">  
-    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2450.622344457853!2d5.077285951700536!3d52.10480437963812!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c66fa9fb18e4b3%3A0x87b3c199ee665619!2sSkyworkz!5e0!3m2!1snl!2snl!4v1557736878153!5m2!1snl!2snl" width="100%" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-    <p>Note that the marker on the map shows the <b>exact</b> location of the Skyworkz office. We share the office with a few other companies, and it's located at the top floor of the building. Streetview doesn't show the entrance yet, but it is there.</p>               
+              <div class="google-map">
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2450.622344457853!2d5.077285951700536!3d52.10480437963812!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c66fa9fb18e4b3%3A0x87b3c199ee665619!2sSkyworkz!5e0!3m2!1snl!2snl!4v1557736878153!5m2!1snl!2snl" width="100%" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+                <p>Note that the marker on the map shows the <b>exact</b> location of the Skyworkz office. We share the office with a few other companies, and it's located at the top floor of the building. Streetview doesn't show the entrance yet, but it is there.</p>
               </div>
             </div>
             {{ end }}
@@ -44,7 +44,8 @@
       <div class="col-12">
           <div class="block">
             <h2>Book a meeting</h2>
-            <div class="calendarhero-inline-widget" data-url="https://meeting.calendarhero.com/meeting/new/6140a9c858a75c0020d98e26/meeting" style="min-width:320px; height:630px;"></div>
+            <p>You can quickly book a meeting with Bas or call yourself using the button below:</p>
+            <a href="https://app.reclaim.ai/m/bas" target="_blank"><button>Schedule Meeting</button></a>
           </div>
         </div>
         </div>

--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -9,7 +9,7 @@
         </div>
         <div class="row">
           <div class="col-lg-6 mx-auto">
-              <a class="btn btn-info mt-lg-2" id="book" onclick="showZoomSidebar()">Book a phone call</a>
+              <a class="btn btn-info mt-lg-2" id="book" href="/contact">Book a phone call</a>
           </div>
         </div>
       </div>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -13,9 +13,8 @@ window.cookieconsent.initialise({
     "theme": "edgeless"
 });
 </script>
-<script type="text/javascript" src="https://app.calendarhero.com/assets/widget.js"></script>
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154801189-1"></script> 
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154801189-1"></script>
 
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
This PR addresses the seemingly broken CalendarHero integration. It rendered an inline planning widget in the footer of every page. As @bastichelaar has moved towards using Reclaim and recently updated the redirects for scheduling links to use Reclaim as well (see PR #85 ), I opted to remove CalendarHero altogether, and implement the Reclaim links as well. 

Reclaim, however, does not currently offer a widget like CalendarHero did, and does not allow you to display the scheduling page in an iframe. For that reason I simply placed a button that redirects to the Reclaim scheduling page. 