### PR TITLE
replace Gitpod link in README with a clear button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This website is built using:
 ## Development
 
 ### GitPod
-The easiest way to work on the Skyworkz website is to use GitPod. GitPod offers a browser-based VSCode setup that has a completely pre-configured setup for the website, including a running Hugo development server. You can use GitPod free of charge with your Github account. To use Gitpod, visit: https://gitpod.io/#https://github.com/skyworkz/website
+The easiest way to work on the Skyworkz website is to use GitPod. GitPod offers a browser-based VSCode setup that has a completely pre-configured setup for the website, including a running Hugo development server. You can use GitPod free of charge with your Github account. To use Gitpod, hit the button below:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/skyworkz/website)
 
 ### Optional: using a Docker image for building the code
 If for some reason, you can't or don't want to use Gitpod, you can use a local Docker setup. If you encounter problems when using `hugo` after `npm install` like `hugo` complaining about SASS stuff, you can use the bundled `Dockerfile` as follows:


### PR DESCRIPTION
This change makes it easier to get started working on the website via Gitpod, as this is way easier to spot. The actual link target is exactly the same. 

Before:
<img width="877" alt="image" src="https://user-images.githubusercontent.com/10847042/208647095-77db57f9-b903-425d-b3a1-530892481c8d.png">

After:
<img width="863" alt="image" src="https://user-images.githubusercontent.com/10847042/208647111-868480bd-f82e-4f39-a259-70ec68e7cd9b.png">
