### PR TITLE
Cloud Coach Questionnaire

### DIFF
--- a/content/blog/launching-cloud-coach.md
+++ b/content/blog/launching-cloud-coach.md
@@ -43,4 +43,4 @@ This makes it easy and convenient to reach out for a quick question, but also me
 We don’t believe in sending a different random engineer to help you every time, even if you’re ‘just a small startup’. Every Cloud Coach client gets a dedicated Cloud Consultant, and they will have an Expert Squad to back them up or to join in when specific expertise is required. Those same people will monitor your Slack Support channel. Familiar faces, who know your people and your setup.
 
 ## Getting Your Personal Coach
-If you think Cloud Coach might be a good fit for your company, or if you want to discuss a move to the cloud, feel free to [reach out](/contact/). Coffee is on us!
+If you think Cloud Coach might be a good fit for your company, or if you want to discuss a move to the cloud, please fill in [our short questionnaire](https://app.formester.com/survey/454e32d9-af60-4b65-b6d4-341e46e18105) and we'll reach out to you. Coffee is on us!

--- a/content/services/cloudcoach.md
+++ b/content/services/cloudcoach.md
@@ -58,3 +58,16 @@ We don’t believe in sending a different random engineer to help you every time
 {{% /col-right-10 %}}
 
 {{</section>}}
+
+{{<section>}}
+{{<raw>}}
+<div class="row mt-5">
+    <div class="col-lg-12 text-center">
+        <p class="divider-subtitle mt-2 text-bold h4">How can Skyworkz help you be successful in the Cloud?</p>
+    </div>
+    <div class="mx-auto text-center">
+        <a class="btn mt-lg-2 btn-warning" id="book" href="https://app.formester.com/survey/454e32d9-af60-4b65-b6d4-341e46e18105">Find out more</a>
+    </div>
+</div>
+{{</raw>}}
+{{</section>}}

--- a/layouts/partials/home-services.html
+++ b/layouts/partials/home-services.html
@@ -15,20 +15,20 @@
                 <div class="icon d-flex align-items-end"><img src="/img/icons/startup.svg" alt="..." class="img-fluid"></div>
                 <h3 class="h4">Cloud Kickstart</h3>
                 <p class="font-weight-light">A full cloud platform up and running in days, including CI/CD, monitoring and support.</p>
-                <a class="" href="/services/kickstart">Cloud Kickstart »</a>
+                <a class="" href="/services/kickstart">Explore Cloud Kickstart »</a>
               </div>
-           </div>  
- 
+           </div>
+
             <div class="col-lg-4">
               <div class="box text-center">
                 <div class="icon d-flex align-items-end"><img src="/img/icons/developer.svg" alt="..." class="img-fluid"></div>
-                <h3 class="h4">Cloud Consultancy</h3>
-                <p class="font-weight-light">Long term or short term engagements: our consultants can help you with cloud related projects.</p>
-                <a class="" href="/services/consultancy">Hire a consultant »</a>
+                <h3 class="h4">Cloud Coach</h3>
+                <p class="font-weight-light">Our Cloud Coaches help you grow your startup into a healthy cloud-native company without breaking the bank.</p>
+                <a class="" href="/services/cloudcoach">Explore Cloud Coach »</a>
               </div>
             </div>
 
-            
+
             <div class="col-lg-4">
               <div class="box text-center">
                 <div class="icon d-flex align-items-end"><img src="/img/icons/training.svg" alt="..." class="img-fluid"></div>


### PR DESCRIPTION
This PR changes 3 things: 
1. Add link to Cloud Coach Questionnaire to Cloud Coach service page
2. Add link to Cloud Coach Questionnaire to Cloud Coach blog post
3. On the home page, swap out 'Consultancy' for 'Cloud Coach' for improved visibility (ideally we should make this a rotating carroussel thing at some point)