### PR TITLE
add explicit taxonomy config, enabling authors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -105,3 +105,7 @@ inst_access = ""
 
 [outputs]
     section = ["html", "json"]
+
+[taxonomies]
+    author = "author"
+    tag = "tags"


### PR DESCRIPTION
This PR enables the 'authors' taxonomy on our website. Specifically, it makes it easy to list all blogposts from a particular author at once. This, in turn, can serve as a link on our Skyworkz resumes. I currently only link to my own personal blog there, but not to `skyworkz.nl/author/benny-cornelissen`. This change makes that possible. 

![image](https://user-images.githubusercontent.com/10847042/228808936-a0cf7592-8b58-4192-9662-6ef248ab733b.png)
